### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -5,3 +5,4 @@
 
 # Fixes
 - Mask and rename enricher configuration api key field
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.KnowledgeGraph/KnowledgeGraphExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.KnowledgeGraph/KnowledgeGraphExternalSearchProvider.cs
@@ -1371,8 +1371,8 @@ namespace CluedIn.ExternalSearch.Providers.KnowledgeGraph
             if (this.IsFiltered(resultItem.Data))
                 yield break;
 
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
-            clue.Data.OriginProviderDefinitionId = this.Id;
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "googleKnowledgeGraph", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var clue = new Clue(code, context.Organization) { Data = { OriginProviderDefinitionId = Id } };
 
             this.PopulateMetadata(clue.Data.EntityData, resultItem, request);
 
@@ -1493,9 +1493,12 @@ namespace CluedIn.ExternalSearch.Providers.KnowledgeGraph
 
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<Result> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "googleKnowledgeGraph", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType         = request.EntityMetaData.EntityType;
             metadata.Name               = request.EntityMetaData.Name;
-            metadata.OriginEntityCode   = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode   = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             metadata.Description        = resultItem.Data.detailedDescription.PrintIfAvailable(v => v.articleBody) ?? resultItem.Data.description;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Knowledge Graph data, but the one from other enricher turn into no source
![image](https://github.com/user-attachments/assets/bbb31848-bf5b-43e7-9ec5-fb1cb637366a)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
